### PR TITLE
Add ccm-page class

### DIFF
--- a/css/bootstrap.less
+++ b/css/bootstrap.less
@@ -55,5 +55,7 @@
 @import "less/utilities.less";
 @import "less/responsive-utilities.less";
 
-//modified 
-@import "modified.less";
+//modified
+div.ccm-page{
+    @import "modified.less";
+}


### PR DESCRIPTION
自由に追加するCSSはccm-pageクラスをつけていた方が、concrete5のメニューに影響がないので追加しました。
